### PR TITLE
Connect ship departure to dock timer

### DIFF
--- a/scenes/Main.gd
+++ b/scenes/Main.gd
@@ -78,7 +78,6 @@ func _ready() -> void:
 			erase_at(pending_erase_cell)
 			pending_erase_cell = Vector2i(-1, -1)
 	)
-
 	add_child(ghost)
 	_update_ghost_def()
 
@@ -227,6 +226,11 @@ func _spawn_ship_for_dock(dock_node: Node2D) -> void:
 	ship.set_route(dock_pos, depart)   # <-- new API
 # existing code…
 	add_child(ship)
+	ship.connect("departed", func():
+		if dock_state.has(dock_node):
+			dock_state[dock_node]["busy"] = false
+			_arm_dock_timer(dock_node)
+	)
 
 	# when ship arrives: spawn a visitor, make them do a shop loop, then ask ship to depart
 	ship.connect("arrived", func():


### PR DESCRIPTION
## Summary
- connect departing ships to reset dock state and schedule next visit

## Testing
- `godot --version` *(fails: command not found)*
- `sudo apt-get install -y godot` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a373efaf8c832e8516e9b5b9687967